### PR TITLE
Change deleteItem to delete

### DIFF
--- a/sendmessage/app.js
+++ b/sendmessage/app.js
@@ -32,7 +32,7 @@ exports.handler = async (event, context) => {
     } catch (e) {
       if (e.statusCode === 410) {
         console.log(`Found stale connection, deleting ${connectionId}`);
-        await ddb.deleteItem({ TableName: TABLE_NAME, Key: { connectionId } }).promise();
+        await ddb.delete({ TableName: TABLE_NAME, Key: { connectionId } }).promise();
       } else {
         throw e;
       }


### PR DESCRIPTION
In line 9 a DocumentClient for DynamoDB is instantiated.
`const ddb = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10' });`

However, in line 35 deleteItem is called.
`await ddb.deleteItem({ TableName: TABLE_NAME, Key: { connectionId } }).promise();`

I tried the example application and in my case the stale connections were not deleted, but also no error message in AWS CloudWatch was logged.
The fix for me was to use ddb.delete instead of deleteItem because according to https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#delete-property there is no deleteItem function but only delete which delegates to deleteItem internally.

This fix is not backed by any tests, I only did try it out locally and then edited directly in the github editor!

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
