### PR TITLE
Fix camelcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ This is the code and template for the simple-websocket-chat-app.  There are thre
 ```
 .
 ├── README.md                   <-- This instructions file
-├── onConnect                   <-- Source code onConnect
-├── onDisconnect                <-- Source code onDisconnect
-├── sendMessage                 <-- Source code sendMessage
+├── onconnect                   <-- Source code onconnect
+├── ondisconnect                <-- Source code ondisconnect
+├── sendmessage                 <-- Source code sendmessage
 └── template.yaml               <-- SAM template for Lambda Functions and DDB
 ```
 

--- a/onconnect/package.json
+++ b/onconnect/package.json
@@ -1,7 +1,7 @@
 {
   "name": "on-connect",
   "version": "1.0.0",
-  "description": "OnConnect example for WebSockets on API Gateway",
+  "description": "onconnect example for WebSockets on API Gateway",
   "main": "src/app.js",
   "author": "SAM CLI",
   "license": "MIT",

--- a/ondisconnect/package.json
+++ b/ondisconnect/package.json
@@ -1,7 +1,7 @@
 {
   "name": "on-disconnect",
   "version": "1.0.0",
-  "description": "OnDisconnect example for WebSockets on API Gateway",
+  "description": "ondisconnect example for WebSockets on API Gateway",
   "main": "src/app.js",
   "author": "SAM CLI",
   "license": "MIT",

--- a/sendmessage/package.json
+++ b/sendmessage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "send-message",
   "version": "1.0.0",
-  "description": "sendMessage example for WebSockets on API Gateway",
+  "description": "sendmessage example for WebSockets on API Gateway",
   "main": "src/app.js",
   "author": "SAM CLI",
   "license": "MIT",

--- a/template.yaml
+++ b/template.yaml
@@ -67,7 +67,7 @@ Resources:
     Type: AWS::ApiGatewayV2::Route
     Properties:
       ApiId: !Ref SimpleChatWebSocket
-      RouteKey: sendMessage
+      RouteKey: sendmessage
       AuthorizationType: NONE
       OperationName: SendRoute
       Target: !Join


### PR DESCRIPTION
*Issue #, if available:*

1. During the change to drop the use of camel case in c8a8121 the README and package.json files were not updated, this change updates those

2. The API Gateway routekey also remained in camel case, updated this which makes this match the value used in the AWS blog post. 
This part was summarised by @armujahid in https://github.com/aws-samples/simple-websockets-chat-app/issues/6#issuecomment-478068306_ which I have broken out into #19.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
