### PR TITLE
add example to README as AWS blog example is out of date

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,26 @@ aws cloudformation describe-stacks \
     --stack-name simple-websocket-chat-app --query 'Stacks[].Outputs'
 ```
 
+## Testing the chat API
+
+To test the WebSocket API, you can use [wscat](https://github.com/websockets/wscat), an open-source command line tool.
+
+1. [Install NPM](https://www.npmjs.com/get-npm).
+2. Install wscat:
+``` bash
+$ npm install -g wscat
+```
+3. On the console, connect to your published API endpoint by executing the following command:
+``` bash
+$ wscat -c wss://{YOUR-API-ID}.execute-api.{YOUR-REGION}.amazonaws.com/{STAGE}
+```
+4. To test the sendMessage function, send a JSON message like the following example. The Lambda function sends it back using the callback URL: 
+``` bash
+$ wscat -c wss://{YOUR-API-ID}.execute-api.{YOUR-REGION}.amazonaws.com/prod
+connected (press CTRL+C to quit)
+> {"message":"sendmessage", "data":"hello world"}
+< hello world
+```
 
 ## License Summary
 


### PR DESCRIPTION
*Issue #, if available:*

As mentioned in comment 1) of #19 the example:
{"action":"sendmessage", "data":"hello world"}
should now be:
{"message":"sendmessage", "data":"hello world"}

Aside to updating the public blog post, this fix adds the correct example to the README.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
