### PR TITLE
Update NodeJS lambda version.

### DIFF
--- a/sendmessage/app.js
+++ b/sendmessage/app.js
@@ -3,9 +3,6 @@
 
 const AWS = require('aws-sdk');
 
-// Add ApiGatewayManagementApi to the AWS namespace
-require('aws-sdk/clients/apigatewaymanagementapi');
-
 const ddb = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10' });
 
 const { TABLE_NAME } = process.env;

--- a/template.yaml
+++ b/template.yaml
@@ -119,7 +119,7 @@ Resources:
       CodeUri: onconnect/
       Handler: app.handler
       MemorySize: 256
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Environment:
         Variables:
           TABLE_NAME: !Ref TableName
@@ -141,7 +141,7 @@ Resources:
       CodeUri: ondisconnect/
       Handler: app.handler
       MemorySize: 256
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Environment:
         Variables:
           TABLE_NAME: !Ref TableName
@@ -163,7 +163,7 @@ Resources:
       CodeUri: sendmessage/
       Handler: app.handler
       MemorySize: 256
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Environment:
         Variables:
           TABLE_NAME: !Ref TableName


### PR DESCRIPTION
*Issue #, if available:*

NodeJS 8.10 Lambda runtime does not have up to date `aws-sdk`. Deploying this repository following just README.md will produce non working example.

Just by bumping NodeJS Lambda version resolves the issue. I have successfully tested the change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
