### PR TITLE
Cleanup code and make it consistent across all handlers

### DIFF
--- a/onconnect/app.js
+++ b/onconnect/app.js
@@ -1,22 +1,23 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-var AWS = require("aws-sdk");
-AWS.config.update({ region: process.env.AWS_REGION });
-var DDB = new AWS.DynamoDB({ apiVersion: "2012-10-08" });
+const AWS = require('aws-sdk');
 
-exports.handler = function (event, context, callback) {
-  var putParams = {
+const ddb = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10', region: process.env.AWS_REGION });
+
+exports.handler = async event => {
+  const putParams = {
     TableName: process.env.TABLE_NAME,
     Item: {
-      connectionId: { S: event.requestContext.connectionId }
+      connectionId: event.requestContext.connectionId
     }
   };
 
-  DDB.putItem(putParams, function (err) {
-    callback(null, {
-      statusCode: err ? 500 : 200,
-      body: err ? "Failed to connect: " + JSON.stringify(err) : "Connected."
-    });
-  });
+  try {
+    await ddb.put(putParams).promise();
+  } catch (err) {
+    return { statusCode: 500, body: 'Failed to connect: ' + JSON.stringify(err) };
+  }
+
+  return { statusCode: 200, body: 'Connected.' };
 };

--- a/ondisconnect/app.js
+++ b/ondisconnect/app.js
@@ -1,22 +1,23 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-var AWS = require("aws-sdk");
-AWS.config.update({ region: process.env.AWS_REGION });
-var DDB = new AWS.DynamoDB({ apiVersion: "2012-10-08" });
+const AWS = require('aws-sdk');
 
-exports.handler = function (event, context, callback) {
-  var deleteParams = {
+const ddb = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10', region: process.env.AWS_REGION });
+
+exports.handler = async event => {
+  const deleteParams = {
     TableName: process.env.TABLE_NAME,
     Key: {
-      connectionId: { S: event.requestContext.connectionId }
+      connectionId: event.requestContext.connectionId
     }
   };
 
-  DDB.deleteItem(deleteParams, function (err) {
-    callback(null, {
-      statusCode: err ? 500 : 200,
-      body: err ? "Failed to disconnect: " + JSON.stringify(err) : "Disconnected."
-    });
-  });
+  try {
+    await ddb.delete(deleteParams).promise();
+  } catch (err) {
+    return { statusCode: 500, body: 'Failed to disconnect: ' + JSON.stringify(err) };
+  }
+
+  return { statusCode: 200, body: 'Disconnected.' };
 };

--- a/sendmessage/app.js
+++ b/sendmessage/app.js
@@ -3,11 +3,11 @@
 
 const AWS = require('aws-sdk');
 
-const ddb = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10' });
+const ddb = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10', region: process.env.AWS_REGION });
 
 const { TABLE_NAME } = process.env;
 
-exports.handler = async (event, context) => {
+exports.handler = async event => {
   let connectionData;
   
   try {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The current sample code was a bit inconsistent between the three handlers. This PR cleans them up and makes them consistent:

* Use async handler instead of callbacks for all three
* Use `AWS.DynamoDB.DocumentClient` for all three
* Use promises when using DynamoDB for all three
* Supply region for DynamoDB for all three

Should be no functional difference, just cleaning it up to be consistent so it's easier to follow rather than coding style changing from file to file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
