### PR TITLE
Bump lambda runtime Node version

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -119,7 +119,7 @@ Resources:
       CodeUri: onconnect/
       Handler: app.handler
       MemorySize: 256
-      Runtime: nodejs10.x
+      Runtime: nodejs12.x
       Environment:
         Variables:
           TABLE_NAME: !Ref TableName
@@ -141,7 +141,7 @@ Resources:
       CodeUri: ondisconnect/
       Handler: app.handler
       MemorySize: 256
-      Runtime: nodejs10.x
+      Runtime: nodejs12.x
       Environment:
         Variables:
           TABLE_NAME: !Ref TableName
@@ -163,7 +163,7 @@ Resources:
       CodeUri: sendmessage/
       Handler: app.handler
       MemorySize: 256
-      Runtime: nodejs10.x
+      Runtime: nodejs12.x
       Environment:
         Variables:
           TABLE_NAME: !Ref TableName


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When I tried to deploy from the SAM CLI, I received a node version error: nodejs10.x being not accepted anymore - bumped it to nodejs12.x and successfully deployed and played with it.
Thanks for the working example guys.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
