### PR TITLE
Update NodeJS Runetime to .18x

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -119,7 +119,7 @@ Resources:
       CodeUri: onconnect/
       Handler: app.handler
       MemorySize: 256
-      Runtime: nodejs14.x
+      Runtime: nodejs16.x
       Environment:
         Variables:
           TABLE_NAME: !Ref TableName

--- a/template.yaml
+++ b/template.yaml
@@ -119,7 +119,7 @@ Resources:
       CodeUri: onconnect/
       Handler: app.handler
       MemorySize: 256
-      Runtime: nodejs16.x
+      Runtime: nodejs18.x
       Environment:
         Variables:
           TABLE_NAME: !Ref TableName


### PR DESCRIPTION
*Issue #, if available:*
Cloud Formation Stack Rolls back because NodeJS is not updated to .18x
*Description of changes:*
Updated NodeJS runtime to .18x

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.  
