### PR TITLE
Construct api end point from apiId, aws region and stage.

### DIFF
--- a/sendmessage/app.js
+++ b/sendmessage/app.js
@@ -18,7 +18,7 @@ exports.handler = async event => {
   
   const apigwManagementApi = new AWS.ApiGatewayManagementApi({
     apiVersion: '2018-11-29',
-    endpoint: event.requestContext.domainName + '/' + event.requestContext.stage
+    endpoint: `${event.requestContext.apiId}.execute-api.${process.env.AWS_REGION}.amazonaws.com/${event.requestContext.stage}`
   });
   
   const postData = JSON.parse(event.body).data;


### PR DESCRIPTION
the domain name property in request context could be a custom domain, in that case, the end point would be custom domain + user configured path (rather than stage). It's more reliable to construct the origin domain name from app id and region directly than relying on the domain property.