### PR TITLE
Aws sdk v3 refactor

### DIFF
--- a/onconnect/app.js
+++ b/onconnect/app.js
@@ -1,21 +1,25 @@
 // Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-const AWS = require('aws-sdk');
+import { DynamoDBClient, PutItemCommand } from "@aws-sdk/client-dynamodb"; 
 
-const ddb = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10', region: process.env.AWS_REGION });
+const ddb = new DynamoDBClient({ region: process.env.AWS_REGION });
 
-exports.handler = async event => {
+// ES6 type module syntax
+export const handler = async (event) => {
+
   const putParams = {
     TableName: process.env.TABLE_NAME,
     Item: {
-      connectionId: event.requestContext.connectionId
+      connectionId: { S: event.requestContext.connectionId }
     }
   };
-
+  const putCmd = new PutItemCommand(putParams);
+   
   try {
-    await ddb.put(putParams).promise();
+    await ddb.send(putCmd);
   } catch (err) {
+
     return { statusCode: 500, body: 'Failed to connect: ' + JSON.stringify(err) };
   }
 

--- a/onconnect/package.json
+++ b/onconnect/package.json
@@ -5,8 +5,7 @@
   "main": "src/app.js",
   "author": "SAM CLI",
   "license": "MIT",
-  "dependencies": {},
-  "devDependencies": {
-    "aws-sdk": "^2.1563.0"
+  "dependencies": {
+    "aws-sdk": "^2.1692.0"
   }
 }

--- a/onconnect/package.json
+++ b/onconnect/package.json
@@ -5,7 +5,5 @@
   "main": "src/app.js",
   "author": "SAM CLI",
   "license": "MIT",
-  "dependencies": {
-    "aws-sdk": "^2.1692.0"
-  }
+  "type": "module"
 }

--- a/ondisconnect/app.js
+++ b/ondisconnect/app.js
@@ -7,20 +7,24 @@
 // $disconnect is a best-effort event. 
 // API Gateway will try its best to deliver the $disconnect event to your integration, but it cannot guarantee delivery.
 
-const AWS = require('aws-sdk');
+import { DynamoDBClient, DeleteItemCommand } from "@aws-sdk/client-dynamodb";
 
-const ddb = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10', region: process.env.AWS_REGION });
+const ddb = new DynamoDBClient({ region: process.env.AWS_REGION });
 
-exports.handler = async event => {
+
+// ES6 type module syntax
+export const handler = async (event) => {
+  
   const deleteParams = {
     TableName: process.env.TABLE_NAME,
     Key: {
-      connectionId: event.requestContext.connectionId
+      connectionId: { S: event.requestContext.connectionId }
     }
   };
+  const delCmd = new DeleteItemCommand(deleteParams);
 
   try {
-    await ddb.delete(deleteParams).promise();
+    await ddb.send(delCmd);
   } catch (err) {
     return { statusCode: 500, body: 'Failed to disconnect: ' + JSON.stringify(err) };
   }

--- a/ondisconnect/package.json
+++ b/ondisconnect/package.json
@@ -5,8 +5,7 @@
   "main": "src/app.js",
   "author": "SAM CLI",
   "license": "MIT",
-  "dependencies": {},
-  "devDependencies": {
-    "aws-sdk": "^2.1563.0"
+  "dependencies": {
+    "aws-sdk": "^2.1692.0"
   }
 }

--- a/ondisconnect/package.json
+++ b/ondisconnect/package.json
@@ -5,7 +5,5 @@
   "main": "src/app.js",
   "author": "SAM CLI",
   "license": "MIT",
-  "dependencies": {
-    "aws-sdk": "^2.1692.0"
-  }
+  "type": "module"
 }

--- a/sendmessage/app.js
+++ b/sendmessage/app.js
@@ -1,35 +1,51 @@
 // Copyright 2018-2020Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-const AWS = require('aws-sdk');
+import { DynamoDBClient, DeleteItemCommand} from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, ScanCommand } from "@aws-sdk/lib-dynamodb";
+import { ApiGatewayManagementApiClient, PostToConnectionCommand } from "@aws-sdk/client-apigatewaymanagementapi";
 
-const ddb = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10', region: process.env.AWS_REGION });
+const ddb = new DynamoDBClient({ region: process.env.AWS_REGION });
+const docClient = DynamoDBDocumentClient.from(ddb);
 
 const { TABLE_NAME } = process.env;
 
-exports.handler = async event => {
-  let connectionData;
+// ES6 type module syntax
+export const handler = async (event) => {
   
+  const scanCmd = new ScanCommand({ TableName: TABLE_NAME, ProjectionExpression: 'connectionId' });
+
+  let connectionData;
   try {
-    connectionData = await ddb.scan({ TableName: TABLE_NAME, ProjectionExpression: 'connectionId' }).promise();
+    connectionData = await docClient.send(scanCmd);
   } catch (e) {
     return { statusCode: 500, body: e.stack };
   }
   
-  const apigwManagementApi = new AWS.ApiGatewayManagementApi({
-    apiVersion: '2018-11-29',
-    endpoint: `${event.requestContext.apiId}.execute-api.${process.env.AWS_REGION}.amazonaws.com/${event.requestContext.stage}`
+  const apigwManagementApi = new ApiGatewayManagementApiClient({
+    endpoint: `https://${event.requestContext.domainName}/${event.requestContext.stage}`
   });
   
   const postData = JSON.parse(event.body).data;
   
   const postCalls = connectionData.Items.map(async ({ connectionId }) => {
     try {
-      await apigwManagementApi.postToConnection({ ConnectionId: connectionId, Data: postData }).promise();
+      const postCmd = new PostToConnectionCommand({ ConnectionId: connectionId, Data: postData });
+      await apigwManagementApi.send(postCmd);
     } catch (e) {
       if (e.statusCode === 410) {
+        
         console.log(`Found stale connection, deleting ${connectionId}`);
-        await ddb.delete({ TableName: TABLE_NAME, Key: { connectionId } }).promise();
+    
+        const deleteParams = {
+          TableName: process.env.TABLE_NAME,
+          Key: {
+            connectionId: { S: event.requestContext.connectionId }
+          }
+        };
+        const delCmd = new DeleteItemCommand(deleteParams);
+        await ddb.send(delCmd);
+
       } else {
         throw e;
       }

--- a/sendmessage/app.js
+++ b/sendmessage/app.js
@@ -23,7 +23,8 @@ export const handler = async (event) => {
   }
   
   const apigwManagementApi = new ApiGatewayManagementApiClient({
-    endpoint: `https://${event.requestContext.domainName}/${event.requestContext.stage}`
+        // The endpoint is intentionally constructed using the API ID and stage from the event to account for custom domains
+    endpoint: `https://${event.requestContext.apiId}.execute-api.${process.env.AWS_REGION}.amazonaws.com/${event.requestContext.stage}`
   });
   
   const postData = JSON.parse(event.body).data;

--- a/sendmessage/package.json
+++ b/sendmessage/package.json
@@ -5,8 +5,7 @@
   "main": "src/app.js",
   "author": "SAM CLI",
   "license": "MIT",
-  "dependencies": {},
-  "devDependencies": {
-    "aws-sdk": "^2.1563.0"
+  "dependencies": {
+    "aws-sdk": "^2.1692.0"
   }
 }

--- a/sendmessage/package.json
+++ b/sendmessage/package.json
@@ -5,7 +5,5 @@
   "main": "src/app.js",
   "author": "SAM CLI",
   "license": "MIT",
-  "dependencies": {
-    "aws-sdk": "^2.1692.0"
-  }
+  "type": "module"
 }


### PR DESCRIPTION
Resolves Issue #60 
- Fixes/Removes missing AWS SDK V2 production dependency in nodejs20.x runtime 
- Refactors handlers to support AWS SDK V3 and ES6 module syntax
- Note that AWS SDK V2 will be reaching end-of-support on September 8, 2025


